### PR TITLE
Add TravisCI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![TravisCI Build Status](https://travis-ci.com/daviddalpiaz/bsl.svg?branch=master)](https://travis-ci.com/daviddalpiaz/bsl)
+
 # Basics of Statistical Learning
 
 ## Chapters


### PR DESCRIPTION
The badge shows build status and provides a link out to travis-ci.com

