### PR TITLE
Add ucidata to list of imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
   caret,
   ellipse,
   gbm,
-  cvms
+  cvms,
+  ucidata
 Remotes:
   coatless/ucidata,
   rstudio/bookdown


### PR DESCRIPTION
`Remotes` just signals what repository to retrieve the package from. 

Need to indicate a requirement for a package using either `Imports:` or `Depends:` in `DESCRIPTION`, where prior is preferred. 
